### PR TITLE
Remove extraneous quote on line 25

### DIFF
--- a/unifi-jail.sh
+++ b/unifi-jail.sh
@@ -22,6 +22,6 @@ iocage exec ${JAIL_NAME} chown -R unifi /usr/local/share/java/unifi
 iocage exec ${JAIL_NAME} sysrc -f /etc/rc.conf ${JAIL_NAME}_enable="YES"
 iocage exec ${JAIL_NAME} sysrc -f /etc/rc.conf mongod_enable="NO"
 iocage exec ${JAIL_NAME} sysrc -f /etc/periodic.conf weekly_dehydrated_enable="YES"
-iocage exec ${JAIL_NAME} sysrc -f /etc/periodic.conf weekly_dehydrated_deployscript="/etc/dehydrated/deploy.sh""
+iocage exec ${JAIL_NAME} sysrc -f /etc/periodic.conf weekly_dehydrated_deployscript="/etc/dehydrated/deploy.sh"
 iocage restart ${JAIL_NAME}
 iocage exec ${JAIL_NAME} sh /etc/dehydrated/deploy.sh


### PR DESCRIPTION
Line 25 has an extra quote at the end, which causes errors running the script.