### PR TITLE
Add quotes around ${JAIL_NAME} in pkcs12 export

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -7,6 +7,6 @@ FQDN=unifi.example.com
 if [ ! -e ${CERTS}/${FQDN}/fullchain.pem ]; then dehydrated -c; fi
 if [ -z ${CERTS}/${FQDN}/fullchain.pem ]; then exit 1; fi
 
-openssl pkcs12 -export -in ${CERTS}/${FQDN}/fullchain.pem -inkey ${CERTS}/${FQDN}/privkey.pem -out ${CERTS}/${FQDN}/signed.p12 -name ${JAIL_NAME} -password pass:aircontrolenterprise
+openssl pkcs12 -export -in ${CERTS}/${FQDN}/fullchain.pem -inkey ${CERTS}/${FQDN}/privkey.pem -out ${CERTS}/${FQDN}/signed.p12 -name "${JAIL_NAME}" -password pass:aircontrolenterprise
 keytool -importkeystore -deststorepass aircontrolenterprise -destkeypass aircontrolenterprise -destkeystore ${UNIFI}/data/keystore -srckeystore ${CERTS}/${FQDN}/signed.p12 -srcstoretype PKCS12 -srcstorepass aircontrolenterprise -alias ${JAIL_NAME} -noprompt
 service ${JAIL_NAME} restart


### PR DESCRIPTION
The openssl pkcs12 export command requires quotes around the name; it will not succeed without them.  Adding quotes to comply with this requirement.